### PR TITLE
Install MkDocs Documentation 3635

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,93 @@
-# Project title and description
+# Documentation
 
-Include a project description that explains **what** your project is and **why** it exists. Aim for no more than 3-5 concise sentences. For example, you might say:
+This documentation is generated with the [MkDocs](https://www.mkdocs.org/) static site generator with the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) design theme. See the respective documentation for detailed information of installation and configuration options.
 
-{Project Name} is a project of Hack for LA. Hack for LA is a brigade of a Code for America that exists to {your mission}. {Project Name} helps {target users} accomplish {goal of project}. The {app/site/thing you're building}'s main features include {very brief feature descriptions}.
+## Initial Installation  
 
-### Project context
+The initial installation of MkDocs included the following files: 
+```
+    mkdocs.yml	                        # MkDocs configuration file
+    docs/
+        index.md                        # folder containing documentation source .md files
+    .github/
+        workflow/
+            ci.yml                      # min. installation of Material theme
+        ISSUE_TEMPLATE/                 # sample template .md files
+    workflow-templates/                 # test files
+    LICENSE
+    README.md                        
+```
+Site is live at [https://hackforla.github.io/website-wiki/](https://hackforla.github.io/website-wiki/)
 
-Civic projects often exist within a larger context that may include multiple stakeholders, historic relationships, associated research, or other details that are relevant but not *required* for direct contributions. Gathering these details in one place is useful, but the ReadMe isn't that place. Use this section to [link to a Google Doc](#) or other documentation repository where contributors can dig in if they so choose. This is also a good place to link to your Code of Conduct.
+## Deploying Documents
+[Documents are deployed](https://www.mkdocs.org/user-guide/deploying-your-docs/) to the `/docs/` folder.
 
-### Technology used
+# Configuration Options  
+Following are descriptions of some of the many configuration options. 
+## MkDocs Plugins  
+Plugins available for use with MkDocs are too numerous to describe here, but includes this list of [MkDocs Plugins](https://github.com/mkdocs/mkdocs/wiki/MkDocs-Plugins). This is also available as a [Best of MkDocs](https://github.com/pawamoy/best-of-mkdocs) list of 180 open-source project plugins ranked by users.  
 
-- Each platform or framework should get its own bullet.
-- Each platform should include an [active link](#) to the official documentation.
+## Material Options  
+The Material for MkDocs design theme includes multiple configuration and extension options. Unless noted otherwise, all configurations and extensions are set in the `mkdocs.yml` configuration file.  
+- Note: Material for MkDocs recommends installation of its [YAML schema validation](https://squidfunk.github.io/mkdocs-material/creating-your-site/#:~:text=Recommended%3A%20configuration%20validation%20and%20auto%2Dcomplete).   
 
-
-
-# How to contribute
-
-Explain the different ways people can contribute. For example:
-
-- Join the team {on Slack/at our weekly hack night/etc}.
-- To help with user research, {do ABC}.
-- To provide design support, {do XYZ}.
-- To contribute to the code, follow the instructions below.
-
-Remember to provide direct links to each channel.
-
-
-
-## Installation instructions
-
-1. Step-by-step instructions help new contributors get a development environment up and running quickly.
-2. You'll want to find the balance between being specific enough for novices to follow, without being so specific that you reinvent the wheel by providing overly-basic instructions that can be found elsewhere.
-3. Feel free to adapt this section and its sub-sections to your own processes.
-4. Alternatively, you can move everything from *Installation instructions* through *Testing* to a separate **Contributing.md** file to keep your **ReadMe.md** more succinct.
-
-
-### Working with issues
-
-- Explain how to submit a bug.
-- Explain how to submit a feature request.
-- Explain how to contribute to an existing issue.
-
-To create a new issue, please use the blank issue template (available when you click New Issue).  If you want to create an issue for other projects to use, please create the issue in your own repository and send a slack message to one of your hack night hosts with the link.
+- Note: MkDocs includes a [live preview server](https://squidfunk.github.io/mkdocs-material/creating-your-site/) in Docker for previewing changes as they are made.  
+  
 
 
-### Working with forks and branches
+### Material design customizations:  
 
-- Explain your guidelines here.
+- [Additional CSS](https://squidfunk.github.io/mkdocs-material/customization/#additional-javascript) - recommended placement of new style sheet 
+- [Additional JS](https://squidfunk.github.io/mkdocs-material/customization/#additional-javascript) - integrating other syntax or custom logic 
+- [Theme extension](https://squidfunk.github.io/mkdocs-material/customization/#extending-the-theme)
 
+### Material design advanced configuration options:  
 
-### Working with pull requests and reviews
+- [Changing the colors](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#changing-the-colors)  
+- [Changing the fonts](https://squidfunk.github.io/mkdocs-material/setup/changing-the-fonts/#changing-the-fonts)  
+- [Changing the language](https://squidfunk.github.io/mkdocs-material/setup/changing-the-language/#changing-the-language)  
+- [Changing the logo and icons](https://squidfunk.github.io/mkdocs-material/setup/changing-the-logo-and-icons/#changing-the-logo-and-icons)  
+- [Ensuring data privacy](https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/#ensuring-data-privacy)  
+- [Setting up navigation](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#setting-up-navigation)  
+- [Setting up site search](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#setting-up-site-search)  
+- [Setting up site analytics](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#setting-up-site-analytics)  
+- [Setting up social cards](https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards/#setting-up-social-cards)  
+- [Setting up a blog](https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/#setting-up-a-blog)  
+- [Setting up tags](https://squidfunk.github.io/mkdocs-material/setup/setting-up-tags/#setting-up-tags)  
+- [Setting up versioning](https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/#setting-up-versioning)  
+- [Setting up the header](https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-header/#setting-up-the-header) 
+- [Setting up the footer](https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#setting-up-the-footer)  
+- [Adding a git repository](https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#adding-a-git-repository)  
+- [Adding a comment system](https://squidfunk.github.io/mkdocs-material/setup/adding-a-comment-system/#adding-a-comment-system)  
+- [Building an optimized site](https://squidfunk.github.io/mkdocs-material/setup/building-an-optimized-site/#building-an-optimized-site)  
+- [Building for offline usage](https://squidfunk.github.io/mkdocs-material/setup/building-for-offline-usage/#building-for-offline-usage)  
 
-- Explain your process.
-
-
-### Testing
-
-- Provide instructions.
-
-
-
-# Contact info
-
-Include at least one way (or more, if possible) to reach your team with questions or comments.
-
-
-### Licensing
-
-Include details about the project's open source status.
-
-*this readme file sourced from [Jessica Sand](http://jessicasand.com/other-stuff/just-enough-docs/)*
+### Python Markdown extension options include:   
+  
+  
+- [Minimal configuration]() when using Material for the first time
+- [Recommended configuration]() that enables all markdown-related features
+- Individual listings of markdown-related config options:
+  - [Abbreviations](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#abbreviations) – ability to add a small tooltip to an element  
+  - [Admonition](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#admonition) – support for call-outs  
+  - [Arithmatex](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#arithmatex) – allows rendering of math typesetting via MathJax  
+  - [Attribute Lists](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#attribute-lists) – allows adding HTML attributes and CSS classes  
+  - [BetterEm](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#betterem) – improves detection to emphasize text using spec. characters, i.e. bold, italic  
+  - [Caret, Mark & Tilde](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#caret-mark-tilde) – add the ability to highlight text and define sub- and superscript  
+  - [Critic](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#critic) – allows usage of Critic Markup to highlight text/ track changes  
+  - [Definition Lists](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#definition-lists) – allows usage of definition/ description lists `dl` in HTML  
+  - [Details](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#details) – ‘supercharges the Admonition extension’ for collapsible call-outs  
+  - [Emoji](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#emoji) – inlines bundled and custom emojis and icons 
+  - [Footnotes](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#footnotes) – allows defining inline footnotes  
+  - [Highlight](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#highlight) – support for syntax highlighting of code blocks 
+  - [InlineHighlight](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#inlinehilite) – built on top of Highlight for highlighting inline code blocks  
+  - [Keys](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#keys) – adds ability to render keyboard keys (e.g. Ctrl + Alt + Del)  
+  - [Markdown in HTML](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#markdown-in-html) – allows wrapping markdown content with custom elements in HTML  
+  - [SmartSymbols](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#smartsymbols) – converts characters into symbols, e.g. fractions, copyright mark, etc.  
+  - [Snippets](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#snippets) – add ability to embed content from arbitrary files into a document  
+  - [SuperFences](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#superfences) – facilitates creation of flowcharts, sequence diagrams, etc.  
+  - [Tabbed]() – allows usage of content tabs  
+  - [Table of Contents](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#table-of-contents) – automatically generates a table of contents
+  - [Tables](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#tables) – adds ability of create tables in markdown  
+  - [Tabbed](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#tabbed) - allows usage of content tabs
+  - [Tasklist](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#tasklist) – allows usage of GitHub Flavored Markdown inspired tasklists  

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The initial installation of MkDocs included the following files:
 Site is live at [https://hackforla.github.io/website-wiki/](https://hackforla.github.io/website-wiki/)
 
 ## Deploying Documents
-[Documents are deployed](https://www.mkdocs.org/user-guide/deploying-your-docs/) to the `/docs/` folder.
+[Documents are deployed](https://www.mkdocs.org/user-guide/deploying-your-docs/) in the appropriate subfolder under the `/docs/` folder. The documents are deployed whenever the `ci.yml` action is run.  
 
 # Configuration Options  
 Following are descriptions of some of the many configuration options. 


### PR DESCRIPTION
Fixes https://github.com/hackforla/website/issues/3635

### What changes did you make and why did you make them ?
- Note that MkDocs is already installed and live
- From discussion with Bonnie in the Sunday meeting, 12 March 23:
  - Added description/ documentation of which files have been installed so far
  - Added list of possible extensions/ plugins/ other options that we may want to consider. These are basic decisions such as adding a format color scheme, TOC, navbars, search capability, etc.