### PR TITLE
Fix relative links for autogenerated tags

### DIFF
--- a/docs/all-pages.md
+++ b/docs/all-pages.md
@@ -7,5 +7,167 @@ hide:
 # All pages A-Z
 
 <!-- TABLE_START -->
+| Index | File Name | Location | H1 Title | Tags |
+| --- | --- | --- | --- | --- |
+| 1 | [a-quick-overview-of-fullstory.md](./pending-audit/marketing-and-analytics/a-quick-overview-of-fullstory.md) | pending-audit/marketing-and-analytics | <span style="color:red">NONE</span> |  |
+| 2 | [about-the-website-development-team.md](./roles/dev/about-the-website-development-team.md) | roles/dev | About the Website Development Team |  |
+| 3 | [about-us-page.md](./pending-audit/pages/about-us-page.md) | pending-audit/pages | About Us |  |
+| 4 | [add-local-user-accounts-to-the-docker-users-group-on-windows-10.md](./pending-audit/how-to/add-local-user-accounts-to-the-docker-users-group-on-windows-10.md) | pending-audit/how-to | <span style="color:red">NONE</span> |  |
+| 5 | [add-new-record.md](./decision-records/add-new-record.md) | decision-records | Adding new records |  |
+| 6 | [advisor-research.md](./roles/research/pending-audit/advisor-research.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 7 | [all-pages.md](.//all-pages.md) |  | All pages A-Z |  |
+| 8 | [analytics-tools.md](./pending-audit/marketing-and-analytics/analytics-tools.md) | pending-audit/marketing-and-analytics | <span style="color:red">NONE</span> |  |
+| 9 | [automations-for-wins-page-using-google-apps-script.md](./roles/dev/pending-audit/automations-for-wins-page-using-google-apps-script.md) | roles/dev/pending-audit | Automations for Wins page using Google Apps Script |  |
+| 10 | [being-a-part-of-the-hack-for-la-dev-team.md](./roles/dev/pending-audit/being-a-part-of-the-hack-for-la-dev-team.md) | roles/dev/pending-audit | Introduction |  |
+| 11 | [capitalize-menu-items-in-nav-bar-and-header.md](./decision-records/not-implemented/capitalize-menu-items-in-nav-bar-and-header.md) | decision-records/not-implemented | Capitalize menu items in nav bar and header | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#not-implemented" class="md-tag" markdown="1">not implemented</a><br> |
+| 12 | [citizen-engagement-page.md](./pending-audit/pages/citizen-engagement-page.md) | pending-audit/pages | Citizen Engagement |  |
+| 13 | [communities-of-practice-yml-file-template.md](./pending-audit/md-file-templates/communities-of-practice-yml-file-template.md) | pending-audit/md-file-templates | the name of the CoP |  |
+| 14 | [complete-research.md](./roles/research/pending-audit/complete-research.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 15 | [convert-docs-to-markdown-with-existing-add-on.md](./decision-records/not-implemented/convert-docs-to-markdown-with-existing-add-on.md) | decision-records/not-implemented | Convert docs to markdown with existing add-on | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#not-implemented" class="md-tag" markdown="1">not implemented</a><br> |
+| 16 | [copywriter.md](./pending-audit/roles/copywriter.md) | pending-audit/roles | <span style="color:red">NONE</span> |  |
+| 17 | [corporate-donor-research.md](./roles/research/pending-audit/corporate-donor-research.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 18 | [corporate-donor.md](./roles/research/pending-audit/corporate-donor.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 19 | [credits-page.md](./pending-audit/pages/credits-page.md) | pending-audit/pages | Credits |  |
+| 20 | [credits-yml-file-template-for-iconography-and-imagery.md](./pending-audit/credits-yml-file-template-for-iconography-and-imagery.md) | pending-audit | The title from the source provider |  |
+| 21 | [credits-yml-file-template-for-tools.md](./pending-audit/credits-yml-file-template-for-tools.md) | pending-audit | The company, organization, or individual providing the tool |  |
+| 22 | [data-scientist.md](./pending-audit/roles/data-scientist.md) | pending-audit/roles | <span style="color:red">NONE</span> |  |
+| 23 | [decision-records.md](./roles/dev/decision-records.md) | roles/dev | Decision Records |  |
+| 24 | [design-system-work.md](./pending-audit/design-system-work.md) | pending-audit | Design System Work |  |
+| 25 | [development-and-production-environments.md](./pending-audit/development-and-production-environments.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 26 | [digital-marketing-overview.md](./pending-audit/marketing-and-analytics/digital-marketing-overview.md) | pending-audit/marketing-and-analytics | <span style="color:red">NONE</span> |  |
+| 27 | [donor-research.md](./roles/research/pending-audit/donor-research.md) | roles/research/pending-audit | RP005: Homepage Redesign Research, Individual Donors |  |
+| 28 | [exit-experience.md](./roles/research/pending-audit/exit-experience.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 29 | [explore-local-machine-linters.md](./decision-records/adopted/explore-local-machine-linters.md) | decision-records/adopted | Explore local machine linters | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#adopted" class="md-tag" markdown="1">adopted</a><br> <a href="../../tags/#role-dev" class="md-tag" markdown="1">role: dev</a><br> |
+| 30 | [figma-housekeeping.md](./pending-audit/figma-housekeeping.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 31 | [finding-new-role-experience.md](./roles/research/pending-audit/finding-new-role-experience.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 32 | [fix-pr-github-actions-bug-with-labels-and-instructions.md](./decision-records/not-implemented/fix-pr-github-actions-bug-with-labels-and-instructions.md) | decision-records/not-implemented | Fix PR GitHub Actions bug with labels and instructions | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#not-implemented" class="md-tag" markdown="1">not implemented</a><br> <a href="../../tags/#role-dev" class="md-tag" markdown="1">role: dev</a><br> |
+| 33 | [general-website-research.md](./roles/research/pending-audit/general-website-research.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 34 | [gha-add-update-label-weekly.md](./roles/dev/pending-audit/github-actions/gha-add-update-label-weekly.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 35 | [gha-github-data.md](./roles/dev/pending-audit/github-actions/gha-github-data.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 36 | [gha-issue-trigger.md](./roles/dev/pending-audit/github-actions/gha-issue-trigger.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 37 | [gha-lint-scss.md](./roles/dev/pending-audit/github-actions/gha-lint-scss.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 38 | [gha-move-closed-issues.md](./roles/dev/pending-audit/github-actions/gha-move-closed-issues.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 39 | [gha-pr-instructions.md](./roles/dev/pending-audit/github-actions/gha-pr-instructions.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 40 | [gha-pull-request-trigger.md](./roles/dev/pending-audit/github-actions/gha-pull-request-trigger.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 41 | [gha-set-pr-labels.md](./roles/dev/pending-audit/github-actions/gha-set-pr-labels.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 42 | [gha-update-team-members.md](./roles/dev/pending-audit/github-actions/gha-update-team-members.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 43 | [gha-vrms-data.md](./roles/dev/pending-audit/github-actions/gha-vrms-data.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 44 | [gha-wr-pr-instructions.md](./roles/dev/pending-audit/github-actions/gha-wr-pr-instructions.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 45 | [gha-wr-pull-request-trigger.md](./roles/dev/pending-audit/github-actions/gha-wr-pull-request-trigger.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 46 | [gha-wr-set-pr-labels.md](./roles/dev/pending-audit/github-actions/gha-wr-set-pr-labels.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 47 | [github-security-updates.md](./pending-audit/onboarding/github-security-updates.md) | pending-audit/onboarding | <span style="color:red">NONE</span> |  |
+| 48 | [good-first-issue.md](./pending-audit/good-first-issue.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 49 | [google-apps-script-development-with-clasp.md](./decision-records/adopted/google-apps-script-development-with-clasp.md) | decision-records/adopted | Google Apps Script development with clasp | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#adopted" class="md-tag" markdown="1">adopted</a><br> <a href="../../tags/#role-dev" class="md-tag" markdown="1">role: dev</a><br> |
+| 50 | [guide-to-the-project-layout-file.md](./roles/dev/pending-audit/site-architecture/guide-to-the-project-layout-file.md) | roles/dev/pending-audit/site-architecture | <span style="color:red">NONE</span> |  |
+| 51 | [hack-for-las-github-actions.md](./roles/dev/pending-audit/github-actions/hack-for-las-github-actions.md) | roles/dev/pending-audit/github-actions | Introduction |  |
+| 52 | [hack-for-las-milestones.md](./pending-audit/hack-for-las-milestones.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 53 | [hack-for-las-site-architecture.md](./roles/dev/pending-audit/site-architecture/hack-for-las-site-architecture.md) | roles/dev/pending-audit/site-architecture | <span style="color:red">NONE</span> |  |
+| 54 | [hand-off-issue-follow-up-by-lead.md](./decision-records/adopted/hand-off-issue-follow-up-by-lead.md) | decision-records/adopted | Hand off issue follow-up by lead | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#adopted" class="md-tag" markdown="1">adopted</a><br> |
+| 55 | [hfla-github-actions.md](./roles/dev/pending-audit/github-actions/hfla-github-actions.md) | roles/dev/pending-audit/github-actions | <span style="color:red">NONE</span> |  |
+| 56 | [hide-button-on-toolkit-page.md](./decision-records/adopted/hide-button-on-toolkit-page.md) | decision-records/adopted | Hide button on Toolkit page | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#adopted" class="md-tag" markdown="1">adopted</a><br> <a href="../../tags/#role-dev" class="md-tag" markdown="1">role: dev</a><br> |
+| 57 | [home-page.md](./pending-audit/pages/home-page.md) | pending-audit/pages | Home |  |
+| 58 | [home.md](./pending-audit/home.md) | pending-audit | Home - Needs Review (was `index.md`) |  |
+| 59 | [homepage-assets.md](./roles/research/pending-audit/homepage-assets.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 60 | [homepage-redesign-research.md](./roles/research/pending-audit/homepage-redesign-research.md) | roles/research/pending-audit | Homepage Redesign Research |  |
+| 61 | [how-to-add-status-labels-to-issues.md](./pending-audit/how-to/how-to-add-status-labels-to-issues.md) | pending-audit/how-to | <span style="color:red">NONE</span> |  |
+| 62 | [how-to-communicate-with-the-team.md](./pending-audit/how-to/how-to-communicate-with-the-team.md) | pending-audit/how-to | Introduction |  |
+| 63 | [how-to-contribute-to-the-wiki.md](./pending-audit/how-to-contribute-to-the-wiki.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 64 | [how-to-create-a-page-on-the-hfla-website.md](./pending-audit/how-to/how-to-create-a-page-on-the-hfla-website.md) | pending-audit/how-to | <span style="color:red">NONE</span> |  |
+| 65 | [how-to-create-issues.md](./pending-audit/how-to/how-to-create-issues.md) | pending-audit/how-to | Introduction |  |
+| 66 | [how-to-deal-with-duplicate-style-classes.md](./pending-audit/how-to-deal-with-duplicate-style-classes.md) | pending-audit | Overview |  |
+| 67 | [how-to-link-to-a-projects-detailed-info-page.md](./pending-audit/how-to-link-to-a-projects-detailed-info-page.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 68 | [how-to-make-svgs-and-other-images-wcag-compliant.md](./pending-audit/how-to-make-svgs-and-other-images-wcag-compliant.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 69 | [how-to-read-and-interpret-labels.md](./pending-audit/how-to/how-to-read-and-interpret-labels.md) | pending-audit/how-to | Introduction |  |
+| 70 | [how-to-resolve-merge-conflicts.md](./pending-audit/how-to-resolve-merge-conflicts.md) | pending-audit | How to use this guide # |  |
+| 71 | [how-to-review-a-pull-request-involving-github-actions.md](./pending-audit/how-to/how-to-review-a-pull-request-involving-github-actions.md) | pending-audit/how-to | <span style="color:red">NONE</span> |  |
+| 72 | [how-to-review-pull-requests.md](./pending-audit/how-to/how-to-review-pull-requests.md) | pending-audit/how-to | <span style="color:red">NONE</span> |  |
+| 73 | [how-to-update-a-feature-branch-with-changes-from-gh-pages.md](./pending-audit/how-to-update-a-feature-branch-with-changes-from-gh-pages.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 74 | [how-to-use-git-gui-in-vs-code.md](./pending-audit/how-to/how-to-use-git-gui-in-vs-code.md) | pending-audit/how-to | <span style="color:red">NONE</span> |  |
+| 75 | [how-to-work-off-of-a-feature-branch.md](./pending-audit/how-to/how-to-work-off-of-a-feature-branch.md) | pending-audit/how-to | <span style="color:red">NONE</span> |  |
+| 76 | [impact-page-assets.md](./roles/research/pending-audit/impact-page-assets.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 77 | [implement-logging-system-for-hfla-github-actions.md](./decision-records/not-implemented/implement-logging-system-for-hfla-github-actions.md) | decision-records/not-implemented | Implement logging system for HFLA GitHub Actions | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#not-implemented" class="md-tag" markdown="1">not implemented</a><br> |
+| 78 | [index.md](.//index.md) |  | Welcome to the [Hack for LA](https://www.hackforla.org) Website Wiki |  |
+| 79 | [index.md](./decision-records/index.md) | decision-records | Decision Records |  |
+| 80 | [index.md](./pending-audit/pages/index.md) | pending-audit/pages | Pages on Hack for LA website <https://hackforla.org> |  |
+| 81 | [index.md](./roles/content/index.md) | roles/content | Content writing |  |
+| 82 | [index.md](./roles/data/index.md) | roles/data | Data science |  |
+| 83 | [index.md](./roles/design/index.md) | roles/design | Design |  |
+| 84 | [index.md](./roles/dev/index.md) | roles/dev | Development |  |
+| 85 | [index.md](./roles/dev/github-actions/index.md) | roles/dev/github-actions | GitHub Actions |  |
+| 86 | [index.md](./roles/product/index.md) | roles/product | Product management |  |
+| 87 | [index.md](./roles/research/index.md) | roles/research | Research |  |
+| 88 | [individual-donor-research.md](./roles/research/pending-audit/individual-donor-research.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 89 | [instructions-for-alt-text.md](./pending-audit/instructions-for-alt-text.md) | pending-audit | Alt Texts |  |
+| 90 | [introduction-to-the-project.md](./pending-audit/onboarding/introduction-to-the-project.md) | pending-audit/onboarding | <span style="color:red">NONE</span> |  |
+| 91 | [join-us-page.md](./pending-audit/pages/join-us-page.md) | pending-audit/pages | Join Us |  |
+| 92 | [joining-the-hackforla-org-website-team.md](./pending-audit/onboarding/joining-the-hackforla-org-website-team.md) | pending-audit/onboarding | <span style="color:red">NONE</span> |  |
+| 93 | [labels-and-milestones.md](./pending-audit/labels-and-milestones.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 94 | [link-projects-to-project-pages.md](./decision-records/adopted/link-projects-to-project-pages.md) | decision-records/adopted | Get project's filename and assign it to a variable | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#adopted" class="md-tag" markdown="1">adopted</a><br> |
+| 95 | [maintain-design-system-webpages.md](./decision-records/not-implemented/maintain-design-system-webpages.md) | decision-records/not-implemented | Maintain design system webpages | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#not-implemented" class="md-tag" markdown="1">not implemented</a><br> |
+| 96 | [meet-the-team.md](./pending-audit/meet-the-team.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 97 | [meetings-and-agendas.md](./pending-audit/meetings-and-agendas.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 98 | [member-feature-page-assets.md](./roles/research/pending-audit/member-feature-page-assets.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 99 | [onboarding-experience.md](./roles/research/pending-audit/onboarding-experience.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 100 | [other-volunteer.md](./pending-audit/roles/other-volunteer.md) | pending-audit/roles | <span style="color:red">NONE</span> |  |
+| 101 | [pages-on-hack-for-la-website.md](./pending-audit/pages/pages-on-hack-for-la-website.md) | pending-audit/pages | Name of page |  |
+| 102 | [partner-persona-research.md](./roles/research/pending-audit/partner-persona-research.md) | roles/research/pending-audit | Partner Persona Research |  |
+| 103 | [partner-research.md](./roles/research/pending-audit/partner-research.md) | roles/research/pending-audit | [Name of Research] |  |
+| 104 | [prevent-liquid-injection-attacks-in-markdown.md](./decision-records/not-implemented/prevent-liquid-injection-attacks-in-markdown.md) | decision-records/not-implemented | Prevent liquid injection attacks in markdown | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#not-implemented" class="md-tag" markdown="1">not implemented</a><br> <a href="../../tags/#role-dev" class="md-tag" markdown="1">role: dev</a><br> |
+| 105 | [product-manager-and-owner.md](./pending-audit/roles/product-manager-and-owner.md) | pending-audit/roles | <span style="color:red">NONE</span> |  |
+| 106 | [project-md-file-template.md](./pending-audit/md-file-templates/project-md-file-template.md) | pending-audit/md-file-templates | 'identification' is the 9 digit ID for your repo in the GitHub API. |  |
+| 107 | [project-terminology.md](./pending-audit/onboarding/project-terminology.md) | pending-audit/onboarding | <span style="color:red">NONE</span> |  |
+| 108 | [projects-page-assets.md](./roles/research/pending-audit/projects-page-assets.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 109 | [projects-page.md](./pending-audit/pages/projects-page.md) | pending-audit/pages | Projects |  |
+| 110 | [receive-project-updates-from-pm.md](./decision-records/not-implemented/receive-project-updates-from-pm.md) | decision-records/not-implemented | Receive project updates from PM | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#not-implemented" class="md-tag" markdown="1">not implemented</a><br> |
+| 111 | [remove-files-from-your-pull-request.md](./pending-audit/how-to/remove-files-from-your-pull-request.md) | pending-audit/how-to | <span style="color:red">NONE</span> |  |
+| 112 | [research-1-volunteer-onboarding-process-research.md](./roles/research/pending-audit/research-1-volunteer-onboarding-process-research.md) | roles/research/pending-audit | Volunteer Onboarding Process Research |  |
+| 113 | [research-10-toolkits-page-research-preference-testing.md](./roles/research/pending-audit/research-10-toolkits-page-research-preference-testing.md) | roles/research/pending-audit | Toolkits Page Research: Preference Testing |  |
+| 114 | [research-11-homepage-research-new-hero-image.md](./roles/research/pending-audit/research-11-homepage-research-new-hero-image.md) | roles/research/pending-audit | Homepage Research: New Hero Image |  |
+| 115 | [research-12-ux-self-test.md](./roles/research/pending-audit/research-12-ux-self-test.md) | roles/research/pending-audit | UX Self-Test |  |
+| 116 | [research-13-zoom-onboarding-experience-survey.md](./roles/research/pending-audit/research-13-zoom-onboarding-experience-survey.md) | roles/research/pending-audit | Zoom Onboarding Experience Survey |  |
+| 117 | [research-2-overall-website-research-usability-testing.md](./roles/research/pending-audit/research-2-overall-website-research-usability-testing.md) | roles/research/pending-audit | Overall Website Research - Usability Testing |  |
+| 118 | [research-3-open-roles-page-research.md](./roles/research/pending-audit/research-3-open-roles-page-research.md) | roles/research/pending-audit | Open Roles Page Research - Usability testing |  |
+| 119 | [research-4-member-feature-page-research.md](./roles/research/pending-audit/research-4-member-feature-page-research.md) | roles/research/pending-audit | Member Feature Page Research |  |
+| 120 | [research-5-homepage-redesign-research.md](./roles/research/pending-audit/research-5-homepage-redesign-research.md) | roles/research/pending-audit | Homepage Redesign Research  |  |
+| 121 | [research-6-user-persona-research.md](./roles/research/pending-audit/research-6-user-persona-research.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 122 | [research-7-impact-page-research.md](./roles/research/pending-audit/research-7-impact-page-research.md) | roles/research/pending-audit | Impact Page Research |  |
+| 123 | [research-8-navigation-tab-research.md](./roles/research/pending-audit/research-8-navigation-tab-research.md) | roles/research/pending-audit | Navigation Tab Research : Usability test |  |
+| 124 | [research-9-wins-page-research.md](./roles/research/pending-audit/research-9-wins-page-research.md) | roles/research/pending-audit | Wins Page Research |  |
+| 125 | [research-being-audited.md](./roles/research/pending-audit/research-being-audited.md) | roles/research/pending-audit | Research being audited |  |
+| 126 | [research-in-progress.md](./roles/research/pending-audit/research-in-progress.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 127 | [research-output-overview.md](./roles/research/pending-audit/research-output-overview.md) | roles/research/pending-audit | Research Output Overview |  |
+| 128 | [research-page-join-us.md](./roles/research/pending-audit/research-page-join-us.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 129 | [research-ready-for-work.md](./roles/research/pending-audit/research-ready-for-work.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 130 | [research-template-roadmap.md](./roles/research/pending-audit/research-template-roadmap.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 131 | [research-templates-2.md](./roles/research/pending-audit/research-templates-2.md) | roles/research/pending-audit | Research Templates |  |
+| 132 | [research-templates.md](./roles/research/pending-audit/research-templates.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 133 | [research-wiki-template.md](./roles/research/pending-audit/research-wiki-template.md) | roles/research/pending-audit | Template for presenting research on wiki |  |
+| 134 | [research.md](./roles/research/pending-audit/research.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 135 | [resources.md](./pending-audit/tools-and-resources/resources.md) | pending-audit/tools-and-resources | <span style="color:red">NONE</span> |  |
+| 136 | [roadmap-template.md](./pending-audit/roadmap-template.md) | pending-audit | Roadmap template |  |
+| 137 | [sdg-yml-template.md](./pending-audit/sdg-yml-template.md) | pending-audit | The Sustainable Development Goal (SDG) number (e.g. 16) |  |
+| 138 | [sitemap-page.md](./pending-audit/pages/sitemap-page.md) | pending-audit/pages | Sitemap |  |
+| 139 | [standardize-html-img-tag.md](./decision-records/adopted/standardize-html-img-tag.md) | decision-records/adopted | Standardize HTML img tag | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#adopted" class="md-tag" markdown="1">adopted</a><br> <a href="../../tags/#role-dev" class="md-tag" markdown="1">role: dev</a><br> |
+| 140 | [standardized-components.md](./roles/dev/pending-audit/site-architecture/standardized-components.md) | roles/dev/pending-audit/site-architecture | <span style="color:red">NONE</span> |  |
+| 141 | [steps-for-developers-working-on-issues-related-to-wins-page.md](./roles/dev/pending-audit/steps-for-developers-working-on-issues-related-to-wins-page.md) | roles/dev/pending-audit | Steps for developers working on issues related to wins page |  |
+| 142 | [success-metrics.md](./pending-audit/marketing-and-analytics/success-metrics.md) | pending-audit/marketing-and-analytics | <span style="color:red">NONE</span> |  |
+| 143 | [tags.md](.//tags.md) |  | Tags |  |
+| 144 | [toolkit-files-template.md](./pending-audit/toolkit-files-template.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 145 | [toolkit-page-recommended-by-filter-usability-test.md](./roles/research/pending-audit/toolkit-page-recommended-by-filter-usability-test.md) | roles/research/pending-audit | Toolkit Page Recommended by Filter Test |  |
+| 146 | [toolkit-page.md](./pending-audit/toolkit-page.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 147 | [toolkit-page.md](./pending-audit/pages/toolkit-page.md) | pending-audit/pages | Toolkit |  |
+| 148 | [toolkits-page-assets.md](./roles/research/pending-audit/toolkits-page-assets.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 149 | [ui-ux-designer.md](./pending-audit/roles/ui-ux-designer.md) | pending-audit/roles | UI/UX Designer |  |
+| 150 | [ui-ux-researcher-start-page.md](./roles/research/pending-audit/ui-ux-researcher-start-page.md) | roles/research/pending-audit | Getting Started |  |
+| 151 | [update-feature-branches-using-merge-commit.md](./decision-records/adopted/update-feature-branches-using-merge-commit.md) | decision-records/adopted | Update feature branches using merge commit | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#adopted" class="md-tag" markdown="1">adopted</a><br> |
+| 152 | [update-gha-with-dependabot.md](./decision-records/adopted/update-gha-with-dependabot.md) | decision-records/adopted | Update GHA with Dependabot | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#adopted" class="md-tag" markdown="1">adopted</a><br> |
+| 153 | [update-project-profile-template.md](./pending-audit/update-project-profile-template.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 154 | [use-merge-commit-for-gh-pages-updates.md](./decision-records/adopted/use-merge-commit-for-gh-pages-updates.md) | decision-records/adopted | Use merge commit for gh-pages updates | <a href="../../tags/#decision-record" class="md-tag" markdown="1">decision record</a><br> <a href="../../tags/#adopted" class="md-tag" markdown="1">adopted</a><br> |
+| 155 | [volunteer-research-org.md](./roles/research/pending-audit/volunteer-research-org.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 156 | [volunteer-research.md](./roles/research/pending-audit/volunteer-research.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 157 | [wcag-2-0-compliance-checkers.md](./pending-audit/wcag-2-0-compliance-checkers.md) | pending-audit | <span style="color:red">NONE</span> |  |
+| 158 | [web-developer.md](./pending-audit/roles/web-developer.md) | pending-audit/roles | Getting Started |  |
+| 159 | [wins-page-assets.md](./roles/research/pending-audit/wins-page-assets.md) | roles/research/pending-audit | <span style="color:red">NONE</span> |  |
+| 160 | [wins-page.md](./pending-audit/pages/wins-page.md) | pending-audit/pages | Wins |  |
 
 <!-- TABLE_END -->

--- a/docs/decision-records/index.md
+++ b/docs/decision-records/index.md
@@ -15,8 +15,8 @@ Links to records are generated on page build according to the  details specified
 
 ### :green_square: Status: Adopted
 <!-- TAGS='adopted' BEGIN -->
-<details markdown><summary class="md-tag-summary">Tags</summary>
-<p><a href="../../tags/#adopted" class="md-tag">adopted</a></p></details>
+<details class="md-tag-details"><summary class="md-tag-summary">Tags</summary>
+<p><a href="/tags/#adopted" class="md-tag">adopted</a></p></details>
 
 - [Standardize HTML img tag](adopted/standardize-html-img-tag.md)
 - [Use merge commit for gh-pages updates](adopted/use-merge-commit-for-gh-pages-updates.md)
@@ -31,8 +31,8 @@ Links to records are generated on page build according to the  details specified
 
 ### :red_square: Status: Not-implemented
 <!-- TAGS='not implemented' BEGIN -->
-<details markdown><summary class="md-tag-summary">Tags</summary>
-<p><a href="../../tags/#not-implemented" class="md-tag">not implemented</a></p></details>
+<details class="md-tag-details"><summary class="md-tag-summary">Tags</summary>
+<p><a href="/tags/#not-implemented" class="md-tag">not implemented</a></p></details>
 
 - [Convert docs to markdown with existing add-on](not-implemented/convert-docs-to-markdown-with-existing-add-on.md)
 - [Maintain design system webpages](not-implemented/maintain-design-system-webpages.md)

--- a/docs/roles/dev/decision-records.md
+++ b/docs/roles/dev/decision-records.md
@@ -14,21 +14,21 @@ See detailed instructions and templates for [adding new records](add-new-record.
 ### :green_square: Status: Adopted
 
 <!-- TAGS='role: dev', 'adopted' BEGIN -->
-<details markdown><summary class="md-tag-summary">Tags</summary>
-<p><a href="../../tags/#role-dev" class="md-tag">role: dev</a> <a href="../../tags/#adopted" class="md-tag">adopted</a></p></details>
+<details class="md-tag-details"><summary class="md-tag-summary">Tags</summary>
+<p><a href="/tags/#adopted" class="md-tag">adopted</a> <a href="/tags/#role-dev" class="md-tag">role: dev</a></p></details>
 
-- [Standardize HTML img tag](../decision-records/adopted/standardize-html-img-tag.md)
-- [Hide button on Toolkit page](../decision-records/adopted/hide-button-on-toolkit-page.md)
-- [Google Apps Script development with clasp](../decision-records/adopted/google-apps-script-development-with-clasp.md)
-- [Explore local machine linters](../decision-records/adopted/explore-local-machine-linters.md)
+- [Standardize HTML img tag](../../decision-records/adopted/standardize-html-img-tag.md)
+- [Hide button on Toolkit page](../../decision-records/adopted/hide-button-on-toolkit-page.md)
+- [Google Apps Script development with clasp](../../decision-records/adopted/google-apps-script-development-with-clasp.md)
+- [Explore local machine linters](../../decision-records/adopted/explore-local-machine-linters.md)
 <!-- TAGS END -->
 
 ### :red_square: Status: Not-implemented
 
 <!-- TAGS='not implemented', 'role: dev' BEGIN -->
-<details markdown><summary class="md-tag-summary">Tags</summary>
-<p><a href="../../tags/#not-implemented" class="md-tag">not implemented</a> <a href="../../tags/#role-dev" class="md-tag">role: dev</a></p></details>
+<details class="md-tag-details"><summary class="md-tag-summary">Tags</summary>
+<p><a href="/tags/#not-implemented" class="md-tag">not implemented</a> <a href="/tags/#role-dev" class="md-tag">role: dev</a></p></details>
 
-- [Prevent liquid injection attacks in markdown](../decision-records/not-implemented/prevent-liquid-injection-attacks-in-markdown.md)
-- [Fix PR GitHub Actions bug with labels and instructions](../decision-records/not-implemented/fix-pr-github-actions-bug-with-labels-and-instructions.md)
+- [Prevent liquid injection attacks in markdown](../../decision-records/not-implemented/prevent-liquid-injection-attacks-in-markdown.md)
+- [Fix PR GitHub Actions bug with labels and instructions](../../decision-records/not-implemented/fix-pr-github-actions-bug-with-labels-and-instructions.md)
 <!-- TAGS END -->

--- a/hooks/page_links_by_tag.py
+++ b/hooks/page_links_by_tag.py
@@ -20,11 +20,14 @@ for filepath in glob.glob("docs/**/*.md", recursive=True):
             required_tags = {tag.strip().strip("'") for tag in required_tags}
 
             # Generate the heading with details and summary tags
+            # Use an absolute path for the href that always points to the root /tags/ directory
             tag_names_with_links = " ".join(
-                [f'<a href="../../tags/#{tag.replace(": ", "-").replace(" ", "-")}" class="md-tag">{tag}</a>' for tag in required_tags]  
-                )
-            heading = f'<!-- TAGS={match.group(1)} BEGIN -->\n<details class="md-tag-details"><summary class="md-tag-summary">Tags</summary>\n<p>{tag_names_with_links}</p></details>\n\n'  
-
+                [
+                    f'<a href="/tags/#{tag.replace(": ", "-").replace(" ", "-")}" class="md-tag">{tag}</a>'
+                    for tag in required_tags
+                ]
+            )
+            heading = f'<!-- TAGS={match.group(1)} BEGIN -->\n<details class="md-tag-details"><summary class="md-tag-summary">Tags</summary>\n<p>{tag_names_with_links}</p></details>\n\n'
 
             # List to store pages that meet the criteria
             matching_pages = []
@@ -43,7 +46,9 @@ for filepath in glob.glob("docs/**/*.md", recursive=True):
                         # Check if the tags meet the criteria
                         tags = set(front_matter.get("tags", []))
                         if required_tags.issubset(tags):
-                            matching_pages.append((other_filepath, front_matter.get("title")))
+                            matching_pages.append(
+                                (other_filepath, front_matter.get("title"))
+                            )
 
             # Generate the markdown content with the links
             generated_content = ""
@@ -75,11 +80,13 @@ for filepath in glob.glob("docs/**/*.md", recursive=True):
 
             # Find the index of the end comment
             end_comment_index = content.find("<!-- TAGS END -->", match.end())
-            if end_comment_index ==-1:
+            if end_comment_index == -1:
                 end_comment_index = len(content)
 
             # Append the content before the placeholder, the heading, and the generated content
-            new_content += content[last_position:match.start()] + heading + generated_content
+            new_content += (
+                content[last_position : match.start()] + heading + generated_content
+            )
             last_position = end_comment_index
 
         # Append the rest of the content


### PR DESCRIPTION
### Issue
Relative path usage in custom python hooks led to broken links on nested documentation pages.

### Resolution
Script modification to generate absolute paths for tag links, targeting the root `tags.md` file.